### PR TITLE
Add Jest with jsdom and test for removeChips

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1248,3 +1248,8 @@ exitBtn.onclick = function (e) {
 };
 
 document.body.appendChild(exitBtn);
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports.removeChips = removeChips;
+}
+

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "roulette-game",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "jsdom": "^22.1.0"
+  },
+  "jest": {
+    "testEnvironment": "jsdom"
+  }
+}

--- a/tests/removeChips.test.js
+++ b/tests/removeChips.test.js
@@ -1,0 +1,33 @@
+const { JSDOM } = require('jsdom');
+const fs = require('fs');
+const path = require('path');
+
+// Load removeChips from app.js without executing the entire script
+const appPath = path.resolve(__dirname, '../assets/js/app.js');
+const fileContent = fs.readFileSync(appPath, 'utf8');
+const removeChipsMatch = fileContent.match(/function removeChips\(\)\{[\s\S]*?\}/);
+let removeChips;
+if (removeChipsMatch) {
+  // eslint-disable-next-line no-new-func
+  removeChips = new Function(`${removeChipsMatch[0]}; return removeChips;`)();
+} else {
+  throw new Error('removeChips function not found');
+}
+
+describe('removeChips', () => {
+  test('removes all elements with class "chip" from the DOM', () => {
+    const dom = new JSDOM('<!doctype html><html><body></body></html>');
+    const { document } = dom.window;
+    global.document = document;
+
+    for (let i = 0; i < 3; i++) {
+      const chip = document.createElement('div');
+      chip.className = 'chip';
+      document.body.appendChild(chip);
+    }
+
+    expect(document.getElementsByClassName('chip').length).toBe(3);
+    removeChips();
+    expect(document.getElementsByClassName('chip').length).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest configuration with jsdom test environment
- export `removeChips` for tests
- create a test that checks `removeChips()` removes all chip elements
- ignore `node_modules`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684abde3f5bc8333b50fc0edd4c6e9d0